### PR TITLE
Fix nginx not configuring on some domains

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -21,7 +21,7 @@ http {
 	types_hash_max_size 2048;
 	# server_tokens off;
 
-	# server_names_hash_bucket_size 64;
+	server_names_hash_bucket_size 64;
 	# server_name_in_redirect off;
 
 	include /etc/nginx/mime.types;


### PR DESCRIPTION
This fixes the following error:

```
nginx: [emerg] could not build server_names_hash, you should increase server_names_hash_bucket_size: 32
```

It occurs while reloading nginx after updating the certificates
if your domain name is strange enough I suppose. This causes
nginx to be stuck in "snikket is starting up" mode, because it
cannot reload its config. When restarting the container, it would
probably crash completely.

See-Also: https://stackoverflow.com/a/13906493/1248008