### PR TITLE
Increase upload limit by 16 bytes to match Prosody

### DIFF
--- a/nginx/https.template
+++ b/nginx/https.template
@@ -35,7 +35,7 @@ server {
     root /var/www/html;
 
     location /upload/ {
-        client_max_body_size 100M;
+        client_max_body_size 104857616; # 100MB + 16 bytes (see Prosody config)
         proxy_pass http://${SNIKKET_TWEAK_INTERNAL_HTTP_HOST}:${SNIKKET_TWEAK_INTERNAL_HTTP_PORT};
         proxy_set_header  Host            $host;
         proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Unsure why this didn't trigger in recent testing, but today I encountered a situation where nginx rejected a 100MB upload. Makes sense, because we didn't add the extra 16 bytes that Prosody now has (https://github.com/snikket-im/snikket-server/commit/ca242ce8a4a5ff2588c64c5813e91e96d96d1aa7).