### PR TITLE
Certificate error reporting

### DIFF
--- a/cert-monitor.sh
+++ b/cert-monitor.sh
@@ -19,6 +19,7 @@ while sleep 10; do
 	fi
 done
 
+# Reload nginx daily to pick up new certificates
 while sleep 86400; do
 	/usr/sbin/nginx -s reload;
 done

--- a/cert-monitor.sh
+++ b/cert-monitor.sh
@@ -12,6 +12,10 @@ while sleep 10; do
 			/usr/local/bin/render-template.sh "/etc/nginx/templates/$proto" "/etc/nginx/sites-enabled/$proto";
 		done
 		/usr/sbin/nginx -s reload
+	elif test -f "/snikket/letsencrypt/has-errors"; then
+		sed -i 's/div\.cert-status-info-problem/div.cert-status-info-pending/' /var/www/html/index.html
+	else
+		sed -i 's/div\.cert-status-info-pending/div.cert-status-info-problem/' /var/www/html/index.html
 	fi
 done
 

--- a/startup.html
+++ b/startup.html
@@ -18,6 +18,10 @@
 		<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 		<meta name="msapplication-TileColor" content="#fbd308">
 		<meta name="theme-color" content="#fbd308">
+		<style>
+			/* The below line is rewritten by cert-monitor, do not modify */
+			div.cert-status-info-problem { display: none }
+		</style>
 	</head>
 	<body style="background-color: #eee">
 		<div style="width: 80%; margin-top: 10%; margin-left: auto; margin-right: auto; background-color: #f8f8f8; padding: 3em;">
@@ -26,10 +30,24 @@
 			<p>We are currently obtaining SSL/TLS certificates to secure your Snikket service.</p>
 			<p>The login page should appear in a moment. If not, please reload the page.</p>
 			<br>
-			<p>If this page appears for more than a few minutes, there may be a problem. Check that
-			   all components of Snikket are started properly, that your DNS is correct, and that port
-			   80 is open.
-			</p>
+			<div class="cert-status-info-pending">
+				<p>If this page appears for more than a few minutes, there may be a problem. Check that
+				   all components of Snikket are started properly, that your DNS is correct, and that port
+				   80 is open.
+				</p>
+			</div>
+			<div class="cert-status-info-problem">
+				<h2>Problem detected!</h2>
+
+				<p>There was a problem obtaining certificates for your Snikket server. Please check that
+				   all required DNS records are set correctly, that port 80 is open, and if you have a
+				   reverse proxy ensure it is configured correctly.
+				</p>
+
+				<p>See our documentation for <a href="https://github.com/snikket-im/snikket-server/blob/master/docs/setup/troubleshooting.md">troubleshooting
+				   certificate problems</a>.
+				</p>
+			</div>
 		</div>
 	</body>
 </html>


### PR DESCRIPTION
This builds upon the new snikket-cert-manager [error reporting ability](https://github.com/snikket-im/snikket-cert-manager/pull/6), to display an informative error on the startup page during initial setup, if obtaining certificates has failed.