### PR TITLE
Fix redirect when using a tweaked https port

### DIFF
--- a/nginx/http.template
+++ b/nginx/http.template
@@ -11,7 +11,7 @@ server {
     }
 
     location / {
-        return 301 https://$host$request_uri;
+        return 301 https://$host:${SNIKKET_TWEAK_HTTPS_PORT}$request_uri;
     }
 }
 


### PR DESCRIPTION
Given settings like

```yaml
SNIKKET_TWEAK_HTTP_PORT: 8080
SNIKKET_TWEAK_HTTPS_PORT: 8443
```

I got redirected from http://localhost:8080 to https://localhost instead of https://localhost:8443 as would be expected