### PR TITLE
Streaming upload handling

### DIFF
--- a/nginx/https.template
+++ b/nginx/https.template
@@ -36,6 +36,8 @@ server {
 
     location /upload/ {
         client_max_body_size 104857616; # 100MB + 16 bytes (see Prosody config)
+        proxy_request_buffering off;
+        proxy_http_version 1.1;
         proxy_pass http://${SNIKKET_TWEAK_INTERNAL_HTTP_HOST}:${SNIKKET_TWEAK_INTERNAL_HTTP_PORT};
         proxy_set_header  Host            $host;
         proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx/snikket-common.template
+++ b/nginx/snikket-common.template
@@ -30,6 +30,8 @@ location /share {
 
 location /upload {
 	client_max_body_size 104857616; # 100MB + 16 bytes (see Prosody config)
+	proxy_request_buffering off;
+	proxy_http_version 1.1;
 	try_files none @prosody;
 }
 

--- a/nginx/snikket-common.template
+++ b/nginx/snikket-common.template
@@ -29,6 +29,7 @@ location /share {
 }
 
 location /upload {
+	client_max_body_size 104857616; # 100MB + 16 bytes (see Prosody config)
 	try_files none @prosody;
 }
 


### PR DESCRIPTION
Two commits, one fixes that larger uploads were blocked by nginx if `SNIKKET_TWEAK_SHARE_DOMAIN` was enabled and another to disable upload buffering because Prosody handles that efficiently already. 