### PR TITLE
nginx: Reduce resource usage

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,10 +1,10 @@
 user www-data;
-worker_processes auto;
+worker_processes 1;
 pid /run/nginx.pid;
 include /etc/nginx/modules-enabled/*.conf;
 
 events {
-	worker_connections 768;
+	worker_connections 128;
 	# multi_accept on;
 }
 


### PR DESCRIPTION
We're running a simple setup for a private chat server, not a public website serving millions of page requests per day. We don't need super scalability, so these numbers can be safely reduced. As a benefit, nginx will use fewer resources.