### PR TITLE
Increase config flexibility

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,10 +2,12 @@
 
 CERT_PATH="/snikket/letsencrypt/live/$SNIKKET_DOMAIN/fullchain.pem"
 
+PROTOS="${SNIKKET_TWEAK_WEB_PROXY_PROTOS:-http https}"
+
 if test -f "$CERT_PATH"; then
 	## Certs already exist - render and deploy configs
 	/usr/local/bin/render-template.sh "/etc/nginx/templates/snikket-common" "/etc/nginx/snippets/snikket-common.conf"
-	for proto in http https; do
+	for proto in $PROTOS; do
 		/usr/local/bin/render-template.sh "/etc/nginx/templates/$proto" "/etc/nginx/sites-enabled/$proto";
 	done
 else

--- a/service/cert-monitor/run
+++ b/service/cert-monitor/run
@@ -23,6 +23,6 @@ while sleep 10; do
 done
 
 # Reload nginx daily to pick up new certificates
-while sleep 86400; do
+while sleep "${SNIKKET_TWEAK_WEB_PROXY_RELOAD_INTERVAL:-86400}"; do
 	/usr/sbin/nginx -s reload;
 done

--- a/service/cert-monitor/run
+++ b/service/cert-monitor/run
@@ -2,13 +2,15 @@
 
 CERT_PATH="/snikket/letsencrypt/live/$SNIKKET_DOMAIN/fullchain.pem"
 
+PROTOS="${SNIKKET_TWEAK_WEB_PROXY_PROTOS:-http https}"
+
 while sleep 10; do
 	if test -f "$CERT_PATH"; then
 		if test -f /etc/nginx/sites-enabled/startup; then
 			rm /etc/nginx/sites-enabled/startup;
 		fi
 		/usr/local/bin/render-template.sh "/etc/nginx/templates/snikket-common" "/etc/nginx/snippets/snikket-common.conf"
-		for proto in http https; do
+		for proto in $PROTOS; do
 			/usr/local/bin/render-template.sh "/etc/nginx/templates/$proto" "/etc/nginx/sites-enabled/$proto";
 		done
 		/usr/sbin/nginx -s reload


### PR DESCRIPTION
This allows configuration of which nginx templates get loaded. It doesn't make much sense to change this, but it may be possible to extend the image with additional templates, and then this becomes more useful.

It also adds the ability to configure the nginx reload interval (previously hard-coded to 24h).