### PR TITLE
Use non-bash specific conditional syntax, fixes #23

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,7 @@ else
 	/usr/local/bin/render-template.sh "/etc/nginx/templates/startup" "/etc/nginx/sites-enabled/startup";
 fi
 
-if [[ "${#SNIKKET_DOMAIN_ASCII}" -gt 35 ]]; then
+if [ "${#SNIKKET_DOMAIN_ASCII}" -gt 35 ]; then
 	sed 's/server_names_hash_bucket_size .*$/server_names_hash_bucket_size 128;/' nginx/nginx.conf;
 fi
 


### PR DESCRIPTION
`[[ ... ]]` is a
[bash](https://manpages.debian.org/bookworm/bash/bash.1.en.html#CONDITIONAL_EXPRESSIONS)
syntax, but `entrypoint.sh` uses `/bin/sh` which might be any
POSIX-compliant shell.

This replaces it with `[  ]` aka `/bin/test` which should be equivalent.
