### PR TITLE
support for reverse proxy in front of web-proxy over http

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ADD nginx/snikket-common.template /etc/nginx/templates/snikket-common
 ADD nginx/startup.template /etc/nginx/templates/startup
 ADD nginx/http.template /etc/nginx/templates/http
 ADD nginx/https.template /etc/nginx/templates/https
+ADD nginx/proxy.template /etc/nginx/templates/proxy
 ADD service /etc/sv
 ADD static /var/www/html/static
 ADD startup.html /var/www/html/index.html

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 export SNIKKET_DOMAIN_ASCII=$(idn2 "$SNIKKET_DOMAIN")
 
@@ -6,7 +6,11 @@ CERT_PATH="/snikket/letsencrypt/live/$SNIKKET_DOMAIN_ASCII/fullchain.pem"
 
 PROTOS="${SNIKKET_TWEAK_WEB_PROXY_PROTOS:-http https}"
 
-if test -f "$CERT_PATH"; then
+if [ "$SNIKKET_REVERSE_PROXIED" = "1" ]; then
+	## assume certs already exist - render and deploy configs
+	/usr/local/bin/render-template.sh "/etc/nginx/templates/snikket-common" "/etc/nginx/snippets/snikket-common.conf"
+	/usr/local/bin/render-template.sh "/etc/nginx/templates/proxy" "/etc/nginx/sites-enabled/proxy";
+elif test -f "$CERT_PATH"; then
 	## Certs already exist - render and deploy configs
 	/usr/local/bin/render-template.sh "/etc/nginx/templates/snikket-common" "/etc/nginx/snippets/snikket-common.conf"
 	for proto in $PROTOS; do

--- a/nginx/proxy.template
+++ b/nginx/proxy.template
@@ -1,0 +1,69 @@
+server {
+    listen ${SNIKKET_TWEAK_HTTP_PORT};
+    listen [::]:${SNIKKET_TWEAK_HTTP_PORT};
+
+    add_header Strict-Transport-Security "max-age=63072000" always;
+
+    server_name ${SNIKKET_DOMAIN_ASCII};
+
+    include "/etc/nginx/snippets/snikket-common.conf";
+}
+
+server {
+    listen ${SNIKKET_TWEAK_HTTP_PORT};
+    listen [::]:${SNIKKET_TWEAK_HTTP_PORT};
+
+    add_header Strict-Transport-Security "max-age=63072000" always;
+
+    server_name share.${SNIKKET_DOMAIN_ASCII};
+
+    root /var/www/html;
+
+    location / {
+        return 301 https://${SNIKKET_DOMAIN_ASCII}/;
+    }
+
+    location /upload/ {
+        client_max_body_size 104857616; # 100MB + 16 bytes (see Prosody config)
+        proxy_request_buffering off;
+        proxy_http_version 1.1;
+        proxy_pass http://${SNIKKET_TWEAK_INTERNAL_HTTP_HOST}:${SNIKKET_TWEAK_INTERNAL_HTTP_PORT};
+        proxy_set_header  Host            $host;
+        proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header  X-Forwarded-Proto https;
+    }
+}
+
+server {
+    listen ${SNIKKET_TWEAK_HTTP_PORT};
+    listen [::]:${SNIKKET_TWEAK_HTTP_PORT};
+
+    add_header Strict-Transport-Security "max-age=63072000" always;
+
+    server_name groups.${SNIKKET_DOMAIN_ASCII};
+
+    root /var/www/html;
+
+    location / {
+        return 301 https://${SNIKKET_DOMAIN_ASCII}/;
+    }
+}
+
+# Fail requests to unknown domains
+server {
+    listen ${SNIKKET_TWEAK_HTTP_PORT} default_server;
+    listen [::]:${SNIKKET_TWEAK_HTTP_PORT} default_server;
+
+    add_header Strict-Transport-Security "max-age=63072000" always;
+
+    error_page 404 /_errors/404_site.html;
+
+    location = /_errors/404_site.html {
+        root /var/www/html;
+        internal;
+    }
+
+    location / {
+        try_files none =404;
+    }
+}


### PR DESCRIPTION
Attempts to make it easier to reverse proxy snikket. Together with [this gist](https://gist.github.com/curiousercreative/95e5efeb990c307a7750b3e8d8ecbb43), solves https://github.com/snikket-im/snikket-selfhosted/issues/13
